### PR TITLE
Add basic perks system plugin with GUI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,48 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.example</groupId>
+  <artifactId>perks</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>Perks</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.release>17</maven.compiler.release>
+  </properties>
+
+    <repositories>
+      <repository>
+        <id>spigot-repo</id>
+        <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+      </repository>
+      <repository>
+        <id>jitpack.io</id>
+        <url>https://jitpack.io</url>
+      </repository>
+    </repositories>
+
+    <dependencies>
+      <dependency>
+        <groupId>org.spigotmc</groupId>
+        <artifactId>spigot-api</artifactId>
+        <version>1.20.1-R0.1-SNAPSHOT</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>mysql</groupId>
+        <artifactId>mysql-connector-java</artifactId>
+        <version>8.0.33</version>
+      </dependency>
+      <dependency>
+        <groupId>com.github.MilkBowl</groupId>
+        <artifactId>VaultAPI</artifactId>
+        <version>1.7</version>
+        <scope>provided</scope>
+      </dependency>
+    </dependencies>
+
+  </project>

--- a/src/main/java/com/example/perks/PerksPlugin.java
+++ b/src/main/java/com/example/perks/PerksPlugin.java
@@ -1,0 +1,95 @@
+package com.example.perks;
+
+import com.example.perks.commands.PerkShopCommand;
+import com.example.perks.commands.PerksCommand;
+import com.example.perks.listeners.PerkEffectListener;
+import com.example.perks.listeners.PerkMenuListener;
+import com.example.perks.managers.DatabaseManager;
+import com.example.perks.managers.PerkManager;
+import com.example.perks.model.Perk;
+import net.milkbowl.vault.economy.Economy;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.RegisteredServiceProvider;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.util.Map;
+
+public class PerksPlugin extends JavaPlugin {
+    private DatabaseManager databaseManager;
+    private PerkManager perkManager;
+    private FileConfiguration messages;
+    private Economy economy;
+    private String prefix;
+
+    @Override
+    public void onEnable() {
+        saveDefaultConfig();
+        saveResource("messages.yml", false);
+        saveResource("menus.yml", false);
+        messages = YamlConfiguration.loadConfiguration(new File(getDataFolder(), "messages.yml"));
+        prefix = messages.getString("prefix", "");
+
+        if (!setupEconomy()) {
+            getServer().getConsoleSender().sendMessage(getMessage("vault-missing", Map.of()));
+            getServer().getPluginManager().disablePlugin(this);
+            return;
+        }
+
+        databaseManager = new DatabaseManager(this);
+        databaseManager.connect();
+
+        perkManager = new PerkManager(this);
+
+        getCommand("perks").setExecutor(new PerksCommand(this, perkManager));
+        getCommand("perkshop").setExecutor(new PerkShopCommand(perkManager));
+        getServer().getPluginManager().registerEvents(new PerkMenuListener(perkManager), this);
+        getServer().getPluginManager().registerEvents(new PerkEffectListener(perkManager), this);
+
+        getServer().getConsoleSender().sendMessage(prefix + getMessage("plugin-enabled", Map.of("version", getDescription().getVersion())));
+    }
+
+    @Override
+    public void onDisable() {
+        if (databaseManager != null) {
+            databaseManager.disconnect();
+        }
+        getServer().getConsoleSender().sendMessage(prefix + getMessage("plugin-disabled", Map.of()));
+    }
+
+    private boolean setupEconomy() {
+        RegisteredServiceProvider<Economy> rsp = getServer().getServicesManager().getRegistration(Economy.class);
+        if (rsp == null) {
+            return false;
+        }
+        economy = rsp.getProvider();
+        return economy != null;
+    }
+
+    public Economy getEconomy() {
+        return economy;
+    }
+
+    public String getMessage(String key, Map<String, String> placeholders) {
+        String msg = messages.getString(key, key);
+        if (msg == null) msg = key;
+        for (Map.Entry<String, String> e : placeholders.entrySet()) {
+            msg = msg.replace("{" + e.getKey() + "}", e.getValue());
+        }
+        return msg.replace('&', '§');
+    }
+
+    public String getPrefix() {
+        return prefix.replace('&', '§');
+    }
+
+    public double getPrice(Perk perk) {
+        return getConfig().getDouble("prices." + perk.getKey(), 0);
+    }
+
+    public void reload() {
+        reloadConfig();
+        messages = YamlConfiguration.loadConfiguration(new File(getDataFolder(), "messages.yml"));
+        prefix = messages.getString("prefix", "");
+    }
+}

--- a/src/main/java/com/example/perks/commands/PerkShopCommand.java
+++ b/src/main/java/com/example/perks/commands/PerkShopCommand.java
@@ -1,0 +1,23 @@
+package com.example.perks.commands;
+
+import com.example.perks.managers.PerkManager;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class PerkShopCommand implements CommandExecutor {
+    private final PerkManager manager;
+
+    public PerkShopCommand(PerkManager manager) {
+        this.manager = manager;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (sender instanceof Player player) {
+            manager.openShop(player);
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/example/perks/commands/PerksCommand.java
+++ b/src/main/java/com/example/perks/commands/PerksCommand.java
@@ -1,0 +1,108 @@
+package com.example.perks.commands;
+
+import com.example.perks.PerksPlugin;
+import com.example.perks.managers.PerkManager;
+import com.example.perks.model.Perk;
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.Map;
+
+public class PerksCommand implements CommandExecutor {
+
+    private final PerksPlugin plugin;
+    private final PerkManager perkManager;
+
+    public PerksCommand(PerksPlugin plugin, PerkManager perkManager) {
+        this.plugin = plugin;
+        this.perkManager = perkManager;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("Only players may use this command.");
+            return true;
+        }
+        if (args.length == 0) {
+            perkManager.openOverview(player);
+            return true;
+        }
+        String sub = args[0].toLowerCase();
+        switch (sub) {
+            case "setprice":
+                if (!sender.hasPermission("nitroperks.admin")) {
+                    sender.sendMessage(plugin.getPrefix() + plugin.getMessage("admin-no-permission", Map.of()));
+                    return true;
+                }
+                if (args.length < 3) return true;
+                Perk perk = Perk.fromString(args[1]);
+                if (perk == null) {
+                    sender.sendMessage(plugin.getPrefix() + plugin.getMessage("invalid-perk", Map.of("perk", args[1])));
+                    return true;
+                }
+                double price;
+                try {
+                    price = Double.parseDouble(args[2]);
+                } catch (NumberFormatException e) {
+                    return true;
+                }
+                plugin.getConfig().set("prices." + perk.getKey(), price);
+                plugin.saveConfig();
+                sender.sendMessage(plugin.getPrefix() + plugin.getMessage("setprice-success", Map.of("perk", perk.getKey(), "price", args[2])));
+                return true;
+            case "add":
+                if (!sender.hasPermission("nitroperks.admin")) {
+                    sender.sendMessage(plugin.getPrefix() + plugin.getMessage("admin-no-permission", Map.of()));
+                    return true;
+                }
+                if (args.length < 3) return true;
+                Player target = Bukkit.getPlayer(args[1]);
+                if (target == null) {
+                    sender.sendMessage(plugin.getPrefix() + plugin.getMessage("invalid-player", Map.of("player", args[1])));
+                    return true;
+                }
+                perk = Perk.fromString(args[2]);
+                if (perk == null) {
+                    sender.sendMessage(plugin.getPrefix() + plugin.getMessage("invalid-perk", Map.of("perk", args[2])));
+                    return true;
+                }
+                perkManager.addPerk(target, perk);
+                sender.sendMessage(plugin.getPrefix() + plugin.getMessage("perk-added", Map.of("player", target.getName(), "perk", perk.getKey())));
+                return true;
+            case "remove":
+                if (!sender.hasPermission("nitroperks.admin")) {
+                    sender.sendMessage(plugin.getPrefix() + plugin.getMessage("admin-no-permission", Map.of()));
+                    return true;
+                }
+                if (args.length < 3) return true;
+                target = Bukkit.getPlayer(args[1]);
+                if (target == null) {
+                    sender.sendMessage(plugin.getPrefix() + plugin.getMessage("invalid-player", Map.of("player", args[1])));
+                    return true;
+                }
+                perk = Perk.fromString(args[2]);
+                if (perk == null) {
+                    sender.sendMessage(plugin.getPrefix() + plugin.getMessage("invalid-perk", Map.of("perk", args[2])));
+                    return true;
+                }
+                perkManager.removePerk(target, perk);
+                sender.sendMessage(plugin.getPrefix() + plugin.getMessage("perk-removed", Map.of("player", target.getName(), "perk", perk.getKey())));
+                return true;
+            case "reload":
+                if (!sender.hasPermission("nitroperks.admin")) {
+                    sender.sendMessage(plugin.getPrefix() + plugin.getMessage("admin-no-permission", Map.of()));
+                    return true;
+                }
+                plugin.reload();
+                sender.sendMessage(plugin.getPrefix() + plugin.getMessage("reload-success", Map.of()));
+                return true;
+            default:
+                perkManager.openOverview(player);
+                return true;
+        }
+    }
+}

--- a/src/main/java/com/example/perks/listeners/PerkEffectListener.java
+++ b/src/main/java/com/example/perks/listeners/PerkEffectListener.java
@@ -1,0 +1,74 @@
+package com.example.perks.listeners;
+
+import com.example.perks.managers.PerkManager;
+import com.example.perks.model.Perk;
+import org.bukkit.Material;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.player.FoodLevelChangeEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.entity.Player;
+
+public class PerkEffectListener implements Listener {
+    private final PerkManager manager;
+
+    public PerkEffectListener(PerkManager manager) {
+        this.manager = manager;
+    }
+
+    @EventHandler
+    public void onFood(FoodLevelChangeEvent event) {
+        if (event.getEntity() instanceof Player player && manager.isActive(player, Perk.NO_HUNGER)) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onFall(EntityDamageEvent event) {
+        if (event.getEntity() instanceof Player player && event.getCause() == EntityDamageEvent.DamageCause.FALL && manager.isActive(player, Perk.NO_FALL)) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onDeath(PlayerDeathEvent event) {
+        Player player = event.getEntity();
+        if (manager.isActive(player, Perk.KEEP_INVENTORY)) {
+            event.setKeepInventory(true);
+            event.getDrops().clear();
+        }
+        if (manager.isActive(player, Perk.KEEP_XP)) {
+            event.setKeepLevel(true);
+            event.setDroppedExp(0);
+        }
+    }
+
+    @EventHandler
+    public void onBlockBreak(BlockBreakEvent event) {
+        Player player = event.getPlayer();
+        boolean tele = manager.isActive(player, Perk.TELEKINESIS);
+        boolean smelt = manager.isActive(player, Perk.INSTANT_SMELT);
+        if (tele || smelt) {
+            Material type = event.getBlock().getType();
+            ItemStack drop = null;
+            if (smelt) {
+                switch (type) {
+                    case IRON_ORE, DEEPSLATE_IRON_ORE -> drop = new ItemStack(Material.IRON_INGOT);
+                    case GOLD_ORE, DEEPSLATE_GOLD_ORE -> drop = new ItemStack(Material.GOLD_INGOT);
+                    default -> {}
+                }
+            }
+            event.setDropItems(false);
+            if (drop == null) {
+                for (ItemStack natural : event.getBlock().getDrops(player.getInventory().getItemInMainHand())) {
+                    player.getInventory().addItem(natural);
+                }
+            } else {
+                player.getInventory().addItem(drop);
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/perks/listeners/PerkMenuListener.java
+++ b/src/main/java/com/example/perks/listeners/PerkMenuListener.java
@@ -1,0 +1,39 @@
+package com.example.perks.listeners;
+
+import com.example.perks.managers.PerkManager;
+import com.example.perks.model.Perk;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+
+public class PerkMenuListener implements Listener {
+    private final PerkManager manager;
+
+    public PerkMenuListener(PerkManager manager) {
+        this.manager = manager;
+    }
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        String title = ChatColor.stripColor(event.getView().getTitle()).toLowerCase();
+        if (!(title.contains("perk"))) {
+            return;
+        }
+        event.setCancelled(true);
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+        if (event.getCurrentItem() == null) return;
+        int slot = event.getRawSlot();
+        Perk[] perks = Perk.values();
+        if (slot >= perks.length) return;
+        Perk perk = perks[slot];
+        if (title.contains("shop")) {
+            manager.purchase(player, perk);
+        } else {
+            manager.toggle(player, perk);
+        }
+    }
+}

--- a/src/main/java/com/example/perks/managers/DatabaseManager.java
+++ b/src/main/java/com/example/perks/managers/DatabaseManager.java
@@ -1,0 +1,47 @@
+package com.example.perks.managers;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class DatabaseManager {
+
+    private final JavaPlugin plugin;
+    private Connection connection;
+
+    public DatabaseManager(JavaPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public void connect() {
+        String host = plugin.getConfig().getString("mysql.host");
+        int port = plugin.getConfig().getInt("mysql.port");
+        String database = plugin.getConfig().getString("mysql.database");
+        String username = plugin.getConfig().getString("mysql.username");
+        String password = plugin.getConfig().getString("mysql.password");
+
+        String url = "jdbc:mysql://" + host + ":" + port + "/" + database + "?useSSL=false";
+        try {
+            connection = DriverManager.getConnection(url, username, password);
+            plugin.getLogger().info("Connected to MySQL database");
+        } catch (SQLException e) {
+            plugin.getLogger().severe("Could not connect to MySQL: " + e.getMessage());
+        }
+    }
+
+    public Connection getConnection() {
+        return connection;
+    }
+
+    public void disconnect() {
+        if (connection != null) {
+            try {
+                connection.close();
+            } catch (SQLException e) {
+                plugin.getLogger().severe("Could not close MySQL connection: " + e.getMessage());
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/perks/managers/PerkManager.java
+++ b/src/main/java/com/example/perks/managers/PerkManager.java
@@ -1,0 +1,117 @@
+package com.example.perks.managers;
+
+import com.example.perks.PerksPlugin;
+import com.example.perks.model.Perk;
+import net.milkbowl.vault.economy.Economy;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+
+import java.util.*;
+
+public class PerkManager {
+    private final PerksPlugin plugin;
+    private final Map<UUID, Set<Perk>> unlocked = new HashMap<>();
+    private final Map<UUID, Set<Perk>> active = new HashMap<>();
+
+    public PerkManager(PerksPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    private Set<Perk> getUnlocked(Player p) {
+        return unlocked.computeIfAbsent(p.getUniqueId(), k -> new HashSet<>());
+    }
+
+    private Set<Perk> getActive(Player p) {
+        return active.computeIfAbsent(p.getUniqueId(), k -> new HashSet<>());
+    }
+
+    public boolean isActive(Player p, Perk perk) {
+        return getActive(p).contains(perk);
+    }
+
+    public boolean hasUnlocked(Player p, Perk perk) {
+        return getUnlocked(p).contains(perk);
+    }
+
+    public void addPerk(Player p, Perk perk) {
+        getUnlocked(p).add(perk);
+    }
+
+    public void removePerk(Player p, Perk perk) {
+        getUnlocked(p).remove(perk);
+        deactivate(p, perk);
+    }
+
+    public void toggle(Player p, Perk perk) {
+        if (!p.hasPermission(perk.getPermission())) {
+            p.sendMessage(plugin.getPrefix() + plugin.getMessage("no-permission", Map.of()));
+            return;
+        }
+        if (!hasUnlocked(p, perk)) {
+            p.sendMessage(plugin.getPrefix() + plugin.getMessage("invalid-perk", Map.of("perk", perk.getKey())));
+            return;
+        }
+        Set<Perk> set = getActive(p);
+        if (set.contains(perk)) {
+            set.remove(perk);
+            perk.remove(p);
+            p.sendMessage(plugin.getPrefix() + plugin.getMessage("toggle-off", Map.of("perk", perk.getKey())));
+        } else {
+            set.add(perk);
+            perk.apply(p);
+            p.sendMessage(plugin.getPrefix() + plugin.getMessage("toggle-on", Map.of("perk", perk.getKey())));
+        }
+    }
+
+    public void deactivate(Player p, Perk perk) {
+        Set<Perk> set = getActive(p);
+        if (set.remove(perk)) {
+            perk.remove(p);
+        }
+    }
+
+    public void openOverview(Player player) {
+        Inventory inv = Bukkit.createInventory(null, 27, ChatColor.translateAlternateColorCodes('&', "&9Perks"));
+        int i = 0;
+        for (Perk perk : Perk.values()) {
+            inv.setItem(i++, perk.createIcon());
+        }
+        player.openInventory(inv);
+    }
+
+    public void openShop(Player player) {
+        Inventory inv = Bukkit.createInventory(null, 27, ChatColor.translateAlternateColorCodes('&', "&bPerk Shop"));
+        int i = 0;
+        for (Perk perk : Perk.values()) {
+            inv.setItem(i++, perk.createIcon());
+        }
+        player.openInventory(inv);
+    }
+
+    public boolean purchase(Player player, Perk perk) {
+        if (!player.hasPermission(perk.getPermission())) {
+            player.sendMessage(plugin.getPrefix() + plugin.getMessage("no-permission", Map.of()));
+            return false;
+        }
+        if (hasUnlocked(player, perk)) {
+            player.sendMessage(plugin.getPrefix() + plugin.getMessage("perk-already", Map.of("player", player.getName(), "perk", perk.getKey())));
+            return false;
+        }
+        Economy eco = plugin.getEconomy();
+        if (eco == null) {
+            return false;
+        }
+        double price = plugin.getPrice(perk);
+        if (!eco.has(player, price)) {
+            player.sendMessage(plugin.getPrefix() + plugin.getMessage("not-enough-money", Map.of("perk", perk.getKey())));
+            return false;
+        }
+        eco.withdrawPlayer(player, price);
+        addPerk(player, perk);
+        player.sendMessage(plugin.getPrefix() + plugin.getMessage("purchase-success", Map.of("perk", perk.getKey(), "price", String.valueOf((int) price))));
+        return true;
+    }
+}

--- a/src/main/java/com/example/perks/model/Perk.java
+++ b/src/main/java/com/example/perks/model/Perk.java
@@ -1,0 +1,208 @@
+package com.example.perks.model;
+
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.SkullMeta;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+
+import java.lang.reflect.Field;
+import java.util.UUID;
+
+import com.mojang.authlib.GameProfile;
+import com.mojang.authlib.properties.Property;
+
+public enum Perk {
+    TELEKINESIS("telekinesis", "nitroperks.perks.telekinesis", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYWJhOGViYzRjNmE4MTczMDk0NzQ5OWJmN2UxZDVlNzNmZWQ2YzFiYjJjMDUxZTk2ZDM1ZWIxNmQyNDYxMGU3In19fQ==") {
+        @Override
+        public void apply(Player p) {
+            // handled in listeners
+        }
+
+        @Override
+        public void remove(Player p) {
+        }
+    },
+    GLOW("glow", "nitroperks.perks.glow", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMjgwNTdhODcyNjFkYzY0OTE0ZmYwYTQ1ZThlYjRhZjFhOWVmMjI0NzNiZmEyZTkwYWE4MGM3YzA4MmYzZmMwNiJ9fX0=") {
+        @Override
+        public void apply(Player p) {
+            p.setGlowing(true);
+        }
+
+        @Override
+        public void remove(Player p) {
+            p.setGlowing(false);
+        }
+    },
+    NO_HUNGER("no-hunger", "nitroperks.perks.no-hunger", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMTU5MWI2MTUyOWQyNWE3ZWNkNmJlYzAwOTQ4ZTZmZTE1NWUzMDA3ZjJkN2ZlNTU5ZjNhODNjNmY4MDhlNDM0ZCJ9fX0=") {
+        @Override
+        public void apply(Player p) {
+        }
+
+        @Override
+        public void remove(Player p) {
+        }
+    },
+    LAVA_RESISTANCE("lava-resistance", "nitroperks.perks.lavaresistance", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNzIxZDA5MzBiZDYxZmVhNGNiOTAyN2IwMGU5NGUxM2Q2MjAyOWM1MjRlYTBiMzI2MGM3NDc0NTdiYTFiY2ZhMSJ9fX0=") {
+        @Override
+        public void apply(Player p) {
+            p.addPotionEffect(new PotionEffect(PotionEffectType.FIRE_RESISTANCE, Integer.MAX_VALUE, 0, true, false));
+        }
+
+        @Override
+        public void remove(Player p) {
+            p.removePotionEffect(PotionEffectType.FIRE_RESISTANCE);
+        }
+    },
+    NO_FALL("no-fall", "nitroperks.perks.no-fall", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNDhkZDBlYjVjMDEwNzhmMTg0MzM0NTY1ZjEzMjQyMTE5YWI1MTQ3Nzc3NDcyMWQ2ZTUzYzcxYzM5ODYxM2E1NiJ9fX0=") {
+        @Override
+        public void apply(Player p) {
+        }
+
+        @Override
+        public void remove(Player p) {
+        }
+    },
+    WATER_BREATH("water-breath", "nitroperks.perks.waterbreath", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNzg0ZGE0YTMxMGI4ZmRlMmJhMzY3ZTg5ZmUwOTkzNjIwNjg3MTBkYzdkNGFiNjJlOTVhZjA4OWJiYWI1YTc3In19fQ==") {
+        @Override
+        public void apply(Player p) {
+            p.addPotionEffect(new PotionEffect(PotionEffectType.WATER_BREATHING, Integer.MAX_VALUE, 0, true, false));
+        }
+
+        @Override
+        public void remove(Player p) {
+            p.removePotionEffect(PotionEffectType.WATER_BREATHING);
+        }
+    },
+    KEEP_XP("keep-xp", "nitroperks.perks.keepxp", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvODdkODg1YjMyYjBkZDJkNmI3ZjFiNTgyYTM0MTg2ZjhhNTM3M2M0NjU4OWEyNzM0MjMxMzJiNDQ4YjgwMzQ2MiJ9fX0=") {
+        @Override
+        public void apply(Player p) {
+        }
+
+        @Override
+        public void remove(Player p) {
+        }
+    },
+    KEEP_INVENTORY("keep-inventory", "nitroperks.perks.keepinventory", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMmE1MDIwY2VjYjAzODg0NzQ2ZWNlNzE2N2E2YWVlOWNiOGM3Y2U1ZDNkYzlkZWNiYzM2OTBiMjIyYzZlMjEyZSJ9fX0=") {
+        @Override
+        public void apply(Player p) {
+        }
+
+        @Override
+        public void remove(Player p) {
+        }
+    },
+    SPEED("speed", "nitroperks.perks.speed", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNmFhZTg3N2E4MjMwN2E1MmZhNDZhZGUzMzMzZTgxYzc5NjNjZTVkODliZmFhYmM2NzkzNGE2MTg2Y2FhOTUifX19") {
+        @Override
+        public void apply(Player p) {
+            p.addPotionEffect(new PotionEffect(PotionEffectType.SPEED, Integer.MAX_VALUE, 0, true, false));
+        }
+
+        @Override
+        public void remove(Player p) {
+            p.removePotionEffect(PotionEffectType.SPEED);
+        }
+    },
+    NIGHT_VISION("night-vision", "nitroperks.perks.nightvision", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNGViNmU0ZDBmOTczNTRhMzk5Njg1MDFmNTgyZTdjZTc4YzcwZDNhMzMzOWE5ZmJmZjAxMGZhMDQ4YjRkNWJhMSJ9fX0=") {
+        @Override
+        public void apply(Player p) {
+            p.addPotionEffect(new PotionEffect(PotionEffectType.NIGHT_VISION, Integer.MAX_VALUE, 0, true, false));
+        }
+
+        @Override
+        public void remove(Player p) {
+            p.removePotionEffect(PotionEffectType.NIGHT_VISION);
+        }
+    },
+    JUMP("jump", "nitroperks.perks.jump", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNzU1MjE1NzUxNjhlOWViNzg5ZDY1OTVkNTJjMzY4YTQ4NTQxZTcyOWI1NWQxMGI3MDRlNDRmYmYyODBkM2I3OSJ9fX0=") {
+        @Override
+        public void apply(Player p) {
+            p.addPotionEffect(new PotionEffect(PotionEffectType.JUMP, Integer.MAX_VALUE, 0, true, false));
+        }
+
+        @Override
+        public void remove(Player p) {
+            p.removePotionEffect(PotionEffectType.JUMP);
+        }
+    },
+    HASTE("haste", "nitroperks.perks.haste", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZmQ5ODY3ZGRhNDdmMjkxODRmMThlYjI2MTc1MGMzYmE0ZDc2MzM4NzgzZDRmNjY5MWJlNTFmY2FlZDFiNTU3In19fQ==") {
+        @Override
+        public void apply(Player p) {
+            p.addPotionEffect(new PotionEffect(PotionEffectType.FAST_DIGGING, Integer.MAX_VALUE, 0, true, false));
+        }
+
+        @Override
+        public void remove(Player p) {
+            p.removePotionEffect(PotionEffectType.FAST_DIGGING);
+        }
+    },
+    FLY("fly", "nitroperks.perks.fly", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvM2FiMTEwNGExZWYzNGI2YjZmOGY5N2I0ZTk1OWFjODBlYWQyNDU1OWFlNWY3MWMzMmQ5MjFkMzQ3ZTJkMjRhZSJ9fX0=") {
+        @Override
+        public void apply(Player p) {
+            p.setAllowFlight(true);
+        }
+
+        @Override
+        public void remove(Player p) {
+            p.setAllowFlight(false);
+            p.setFlying(false);
+        }
+    },
+    INSTANT_SMELT("instant-smelt", "nitroperks.perks.instantsmelt", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvODYzYmQ5Y2JjYWMzOGIzYWQ0MzVkMTY5ODVmZGE4YzVkMjQ4ZWM5ZWE0NzkxNTE2M2NmYTc4YTM4MTAzNmNhOCJ9fX0=") {
+        @Override
+        public void apply(Player p) {
+        }
+
+        @Override
+        public void remove(Player p) {
+        }
+    };
+
+    private final String key;
+    private final String permission;
+    private final String texture;
+
+    Perk(String key, String permission, String texture) {
+        this.key = key;
+        this.permission = permission;
+        this.texture = texture;
+    }
+
+    public abstract void apply(Player p);
+    public abstract void remove(Player p);
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getPermission() {
+        return permission;
+    }
+
+    public ItemStack createIcon() {
+        ItemStack head = new ItemStack(Material.PLAYER_HEAD);
+        SkullMeta meta = (SkullMeta) head.getItemMeta();
+        GameProfile profile = new GameProfile(UUID.randomUUID(), null);
+        profile.getProperties().put("textures", new Property("textures", texture));
+        try {
+            Field profileField = meta.getClass().getDeclaredField("profile");
+            profileField.setAccessible(true);
+            profileField.set(meta, profile);
+        } catch (Exception ignored) {
+        }
+        meta.setDisplayName(ChatColor.AQUA + key);
+        head.setItemMeta(meta);
+        return head;
+    }
+
+    public static Perk fromString(String s) {
+        for (Perk perk : values()) {
+            if (perk.key.equalsIgnoreCase(s)) {
+                return perk;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,41 @@
+# NitroPerks - General Settings
+use-messages-yml: true
+
+mysql:
+  host: localhost
+  port: 3306
+  database: perks
+  username: root
+  password: password
+
+prices:
+  telekinesis: 1200000
+  glow: 540000
+  no-hunger: 80000
+  lava-resistance: 1200000
+  no-fall: 670000
+  water-breath: 90000
+  keep-xp: 750000
+  keep-inventory: 750000
+  speed: 450000
+  night-vision: 350000
+  jump: 350000
+  haste: 450000
+  fly: 150000
+  instant-smelt: 115000
+
+permissions:
+  telekinesis: nitroperks.perks.telekinesis
+  glow: nitroperks.perks.glow
+  no-hunger: nitroperks.perks.no-hunger
+  lava-resistance: nitroperks.perks.lavaresistance
+  no-fall: nitroperks.perks.no-fall
+  water-breath: nitroperks.perks.waterbreath
+  keep-xp: nitroperks.perks.keepxp
+  keep-inventory: nitroperks.perks.keepinventory
+  speed: nitroperks.perks.speed
+  night-vision: nitroperks.perks.nightvision
+  jump: nitroperks.perks.jump
+  haste: nitroperks.perks.haste
+  fly: nitroperks.perks.fly
+  instant-smelt: nitroperks.perks.instantsmelt

--- a/src/main/resources/menus.yml
+++ b/src/main/resources/menus.yml
@@ -1,0 +1,59 @@
+# NitroPerks – GUI Configuration
+# Simplified menu configuration for perks and shop.
+
+templates:
+  enabled:
+    material: LIME_DYE
+    name: '&aEnabled'
+    lore:
+      - ''
+      - '&7This perk is currently &aactive&7.'
+  disabled:
+    material: GRAY_DYE
+    name: '&7Disabled'
+    lore:
+      - ''
+      - '&7This perk is currently &cinactive&7.'
+  notclaimed:
+    material: REDSTONE
+    name: '&cNot Claimed'
+    lore:
+      - ''
+      - '&7You have not claimed this perk yet.'
+  claimed:
+    material: BARRIER
+    name: '&cAlready Claimed'
+    lore:
+      - ''
+      - '&7You already own this perk.'
+  buy:
+    material: EMERALD
+    name: '&aBuy'
+    lore:
+      - '&7Click to purchase this perk'
+      - '&fPrice &8» &7{price}'
+
+main-menu:
+  rows: 3
+  title: '&x&D&6&9&A&0&0&lP&x&D&6&A&E&0&0&lE&x&7&8&A&2&5&B&lR&x&2&1&9&8&B&E&lK&x&3&2&B&1&D&9&lS'
+  items: {}
+
+shop-menu:
+  page1:
+    rows: 4
+    title: '&x&B&4&B&6&3&0&lP&x&B&4&A&E&3&4&lE&x&B&4&A&5&3&8&lR&x&B&4&9&D&3&C&lK&x&B&4&9&4&4&0&lS &8| &fShop'
+    items: {}
+  page2:
+    rows: 4
+    title: '&x&B&4&B&6&3&0&lP&x&B&4&A&E&3&4&lE&x&B&4&A&5&3&8&lR&x&B&4&9&D&3&C&lK&x&B&4&9&4&4&0&lS &8| &fShop'
+    items: {}
+
+perks-overview:
+  page1:
+    rows: 4
+    title: '&x&B&4&B&6&3&0&lP&x&B&4&A&E&3&4&lE&x&B&4&A&5&3&8&lR&x&B&4&9&D&3&C&lK&x&B&4&9&4&4&0&lS &8| &fOverview'
+    items: {}
+  page2:
+    rows: 4
+    title: '&x&B&4&B&6&3&0&lP&x&B&4&A&E&3&4&lE&x&B&4&A&5&3&8&lR&x&B&4&9&D&3&C&lK&x&B&4&9&4&4&0&lS &8| &fOverview'
+    items: {}

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -1,0 +1,28 @@
+# NitroPerks - Messages
+prefix: '&x&D&6&9&A&0&0&lP&x&D&6&A&E&0&0&lE&x&7&8&A&2&5&B&lR&x&2&1&9&8&B&E&lK&x&3&2&B&1&D&9&lS &8» '
+
+# General
+no-permission: '&cYou do not have permission to use this command.'
+invalid-player: '&cPlayer &e{player}&c not found.'
+invalid-perk: '&cPerk &e{perk}&c not recognized.'
+perk-already: '&cPlayer &e{player}&c already has &e{perk}&c.'
+perk-added: '&aGave &e{perk}&a to &e{player}&a.'
+perk-removed: '&aRemoved &e{perk}&a from &e{player}&a.'
+reload-success: '&aConfiguration reloaded successfully.'
+admin-no-permission: '&cYou need &enitroperks.admin &cto use this command.'
+
+# Shop & Economy
+not-enough-money: '&cYou do not have enough money to buy &e{perk}&c!'
+purchase-success: '&aYou purchased &e{perk}&a for &e{price}&a.'
+
+# Set Price
+setprice-success: '&aSet price of &e{perk}&a to &e{price}&a.'
+
+# Vault Integration
+vault-missing: '&cVault or an economy plugin not found. Disabling NitroPerks.'
+
+# Enabled / Disabled
+plugin-enabled: '&aNitroPerks v{version} enabled.'
+plugin-disabled: '&eNitroPerks disabled.'
+toggle-on: '&aActivated &e{perk}&a!'
+toggle-off: '&cDeactivated &e{perk}&c!'

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,0 +1,16 @@
+name: Perks
+version: 1.0
+main: com.example.perks.PerksPlugin
+api-version: '1.20'
+commands:
+  perks:
+    description: Manage and toggle perks
+    usage: /perks
+    aliases: [perk]
+  perkshop:
+    description: Open the perk shop
+    usage: /perkshop
+permissions:
+  nitroperks.admin:
+    description: Allows administrative perk commands
+    default: op


### PR DESCRIPTION
## Summary
- organize plugin into command, listener, and manager packages
- add MySQL DatabaseManager and configuration file
- declare MySQL connector dependency for database access
- implement perk GUI, shop, and perk effects with Vault economy

## Testing
- `mvn -q package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1329979f4832ead1203d6db3b99ec