### PR TITLE
Fix missing dependencies and imports for successful build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,12 @@
         <version>1.7</version>
         <scope>provided</scope>
       </dependency>
+      <dependency>
+        <groupId>com.mojang</groupId>
+        <artifactId>authlib</artifactId>
+        <version>1.5.21</version>
+        <scope>provided</scope>
+      </dependency>
     </dependencies>
 
   </project>

--- a/src/main/java/com/example/perks/PerksPlugin.java
+++ b/src/main/java/com/example/perks/PerksPlugin.java
@@ -8,6 +8,7 @@ import com.example.perks.managers.DatabaseManager;
 import com.example.perks.managers.PerkManager;
 import com.example.perks.model.Perk;
 import net.milkbowl.vault.economy.Economy;
+import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.RegisteredServiceProvider;
 import org.bukkit.plugin.java.JavaPlugin;

--- a/src/main/java/com/example/perks/listeners/PerkEffectListener.java
+++ b/src/main/java/com/example/perks/listeners/PerkEffectListener.java
@@ -8,7 +8,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
-import org.bukkit.event.player.FoodLevelChangeEvent;
+import org.bukkit.event.entity.FoodLevelChangeEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.entity.Player;
 


### PR DESCRIPTION
## Summary
- import Bukkit's `FileConfiguration` in the main plugin class
- correct `FoodLevelChangeEvent` import and usage
- add Mojang `authlib` as a provided dependency for `GameProfile`

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1385016a0832e9e9e4c19dc767208