### PR TITLE
Add Minecraft libraries repo for AuthLib dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,10 @@
         <id>jitpack.io</id>
         <url>https://jitpack.io</url>
       </repository>
+      <repository>
+        <id>minecraft-libraries</id>
+        <url>https://libraries.minecraft.net/</url>
+      </repository>
     </repositories>
 
     <dependencies>


### PR DESCRIPTION
## Summary
- Add `minecraft-libraries` repository to resolve Mojang AuthLib dependency

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Could not transfer artifact... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1393c1d9c832eb554de427ebc9ae0