### PR TITLE
Fix NPE when creating perk icon profiles

### DIFF
--- a/src/main/java/com/example/perks/model/Perk.java
+++ b/src/main/java/com/example/perks/model/Perk.java
@@ -184,7 +184,13 @@ public enum Perk {
     public ItemStack createIcon() {
         ItemStack head = new ItemStack(Material.PLAYER_HEAD);
         SkullMeta meta = (SkullMeta) head.getItemMeta();
-        GameProfile profile = new GameProfile(UUID.randomUUID(), null);
+        // The GameProfile constructor no longer accepts a null name in recent
+        // versions of the authentication library. Using a null value here caused
+        // a NullPointerException when the perks menu attempted to create the
+        // custom skull icon for a perk. To avoid this we provide a non-null
+        // profile name; the actual value is irrelevant for our custom texture, so
+        // we simply reuse the perk's key as the profile's name.
+        GameProfile profile = new GameProfile(UUID.randomUUID(), key);
         profile.getProperties().put("textures", new Property("textures", texture));
         try {
             Field profileField = meta.getClass().getDeclaredField("profile");


### PR DESCRIPTION
## Summary
- Avoid GameProfile null name when creating custom perk head icons
- Document reasoning for using perk key as profile name

## Testing
- `mvn test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central: Network is unreachable)*
- `mvn -o -DskipTests package` *(fails: Cannot access central in offline mode and the artifact maven-resources-plugin has not been downloaded)*

------
https://chatgpt.com/codex/tasks/task_e_68abded05d9c832ebefe6efbe4e1d041